### PR TITLE
Unset Id on 404 Not Found status

### DIFF
--- a/kong/resource_kong_api.go
+++ b/kong/resource_kong_api.go
@@ -183,7 +183,10 @@ func resourceKongAPIRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error while updating API" + error.Error())
 	}
 
-	if response.StatusCode != http.StatusOK {
+	if response.StatusCode == http.StatusNotFound {
+		d.SetId("")
+		return nil
+	} else if response.StatusCode != http.StatusOK {
 		return fmt.Errorf("unexpected status code received: " + response.Status)
 	}
 

--- a/kong/resource_kong_api_plugin.go
+++ b/kong/resource_kong_api_plugin.go
@@ -89,7 +89,10 @@ func resourceKongPluginRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error while updating plugin: " + error.Error())
 	}
 
-	if response.StatusCode != http.StatusOK {
+	if response.StatusCode == http.StatusNotFound {
+		d.SetId("")
+		return nil
+	} else if response.StatusCode != http.StatusOK {
 		return fmt.Errorf("unexpected status code received: " + response.Status)
 	}
 

--- a/kong/resource_kong_consumer.go
+++ b/kong/resource_kong_consumer.go
@@ -76,7 +76,10 @@ func resourceKongConsumerRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error while updating consumer.")
 	}
 
-	if response.StatusCode != http.StatusOK {
+	if response.StatusCode == http.StatusNotFound {
+		d.SetId("")
+		return nil
+	} else if response.StatusCode != http.StatusOK {
 		return fmt.Errorf(response.Status)
 	}
 

--- a/kong/resource_kong_consumer_credential_basic_auth.go
+++ b/kong/resource_kong_consumer_credential_basic_auth.go
@@ -80,7 +80,10 @@ func resourceKongBasicAuthCredentialRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error while updating basicAuthCredential.")
 	}
 
-	if response.StatusCode != http.StatusOK {
+	if response.StatusCode == http.StatusNotFound {
+		d.SetId("")
+		return nil
+	} else if response.StatusCode != http.StatusOK {
 		return fmt.Errorf(response.Status)
 	}
 

--- a/kong/resource_kong_consumer_credential_jwt.go
+++ b/kong/resource_kong_consumer_credential_jwt.go
@@ -97,7 +97,10 @@ func resourceKongJWTCredentialRead(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("Error while updating jwtCredential.")
 	}
 
-	if response.StatusCode != http.StatusOK {
+	if response.StatusCode == http.StatusNotFound {
+		d.SetId("")
+		return nil
+	} else if response.StatusCode != http.StatusOK {
 		return fmt.Errorf(response.Status)
 	}
 

--- a/kong/resource_kong_consumer_credential_key_auth.go
+++ b/kong/resource_kong_consumer_credential_key_auth.go
@@ -73,7 +73,10 @@ func resourceKongKeyAuthCredentialRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error while updating keyAuthCredential.")
 	}
 
-	if response.StatusCode != http.StatusOK {
+	if response.StatusCode == http.StatusNotFound {
+		d.SetId("")
+		return nil
+	} else if response.StatusCode != http.StatusOK {
 		return fmt.Errorf(response.Status)
 	}
 

--- a/kong/resource_kong_key_auth_plugin.go
+++ b/kong/resource_kong_key_auth_plugin.go
@@ -90,7 +90,10 @@ func resourceKeyAuthPluginRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error while updating plugin.")
 	}
 
-	if response.StatusCode != http.StatusOK {
+	if response.StatusCode == http.StatusNotFound {
+		d.SetId("")
+		return nil
+	} else if response.StatusCode != http.StatusOK {
 		return fmt.Errorf(response.Status)
 	}
 


### PR DESCRIPTION
If a 404 is encountered reading any terraform managed kong resources we
know that it was removed out of the scope of this provider and should be
marked for recreation.

**NOTE**: We could potentially implement some of these as [Exists](https://www.terraform.io/docs/plugins/provider.html#exists) but I imagine that'd add an extra API request which just implementing the existance check in read alleviates.