### PR TITLE
Support terraform import of kong resources

### DIFF
--- a/kong/import_consumer_credential.go
+++ b/kong/import_consumer_credential.go
@@ -1,0 +1,19 @@
+package kong
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func ImportConsumerCredential(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("Expected a string in the format \"<consumer_id>/<credential_id>\" to import.")
+	}
+
+	d.Set("consumer", parts[0])
+	d.SetId(parts[1])
+	return []*schema.ResourceData{d}, nil
+}

--- a/kong/resource_kong_api.go
+++ b/kong/resource_kong_api.go
@@ -166,7 +166,9 @@ func resourceKongAPICreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error while creating API: " + error.Error())
 	}
 
-	if response.StatusCode != http.StatusCreated {
+	if response.StatusCode == http.StatusConflict {
+		return fmt.Errorf("409 Conflict - use terraform import to manage this api.")
+	} else if response.StatusCode != http.StatusCreated {
 		return fmt.Errorf("unexpected status code received: " + response.Status)
 	}
 

--- a/kong/resource_kong_api.go
+++ b/kong/resource_kong_api.go
@@ -52,6 +52,10 @@ func resourceKongAPI() *schema.Resource {
 		Update: resourceKongAPIUpdate,
 		Delete: resourceKongAPIDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"id": &schema.Schema{
 				Type:     schema.TypeString,

--- a/kong/resource_kong_api_plugin.go
+++ b/kong/resource_kong_api_plugin.go
@@ -13,7 +13,7 @@ type Plugin struct {
 	ID            string                 `json:"id,omitempty"`
 	Name          string                 `json:"name,omitempty"`
 	Configuration map[string]interface{} `json:"config,omitempty"`
-	API           string                 `json:"-"`
+	API           string                 `json:"api_id,omitempty"`
 }
 
 func resourceKongPlugin() *schema.Resource {

--- a/kong/resource_kong_api_plugin.go
+++ b/kong/resource_kong_api_plugin.go
@@ -67,7 +67,9 @@ func resourceKongPluginCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error while creating plugin: " + error.Error())
 	}
 
-	if response.StatusCode != http.StatusCreated {
+	if response.StatusCode == http.StatusConflict {
+		return fmt.Errorf("409 Conflict - use terraform import to manage this plugin.")
+	} else if response.StatusCode != http.StatusCreated {
 		return fmt.Errorf("unexpected status code received: " + response.Status)
 	}
 

--- a/kong/resource_kong_api_plugin.go
+++ b/kong/resource_kong_api_plugin.go
@@ -23,6 +23,10 @@ func resourceKongPlugin() *schema.Resource {
 		Update: resourceKongPluginUpdate,
 		Delete: resourceKongPluginDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"id": &schema.Schema{
 				Type:     schema.TypeString,

--- a/kong/resource_kong_consumer.go
+++ b/kong/resource_kong_consumer.go
@@ -60,7 +60,9 @@ func resourceKongConsumerCreate(d *schema.ResourceData, meta interface{}) error 
 		return fmt.Errorf("Error while creating consumer.")
 	}
 
-	if response.StatusCode != http.StatusCreated {
+	if response.StatusCode == http.StatusConflict {
+		return fmt.Errorf("409 Conflict - use terraform import to manage this consumer.")
+	} else if response.StatusCode != http.StatusCreated {
 		return fmt.Errorf(response.Status)
 	}
 

--- a/kong/resource_kong_consumer.go
+++ b/kong/resource_kong_consumer.go
@@ -21,6 +21,10 @@ func resourceKongConsumer() *schema.Resource {
 		Update: resourceKongConsumerUpdate,
 		Delete: resourceKongConsumerDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"id": &schema.Schema{
 				Type:     schema.TypeString,

--- a/kong/resource_kong_consumer_credential_basic_auth.go
+++ b/kong/resource_kong_consumer_credential_basic_auth.go
@@ -22,6 +22,10 @@ func resourceKongBasicAuthCredential() *schema.Resource {
 		Update: resourceKongBasicAuthCredentialUpdate,
 		Delete: resourceKongBasicAuthCredentialDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"id": &schema.Schema{
 				Type:     schema.TypeString,

--- a/kong/resource_kong_consumer_credential_basic_auth.go
+++ b/kong/resource_kong_consumer_credential_basic_auth.go
@@ -23,7 +23,7 @@ func resourceKongBasicAuthCredential() *schema.Resource {
 		Delete: resourceKongBasicAuthCredentialDelete,
 
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: ImportConsumerCredential,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/kong/resource_kong_consumer_credential_jwt.go
+++ b/kong/resource_kong_consumer_credential_jwt.go
@@ -25,7 +25,7 @@ func resourceKongJWTCredential() *schema.Resource {
 		Delete: resourceKongJWTCredentialDelete,
 
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: ImportConsumerCredential,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/kong/resource_kong_consumer_credential_jwt.go
+++ b/kong/resource_kong_consumer_credential_jwt.go
@@ -24,6 +24,10 @@ func resourceKongJWTCredential() *schema.Resource {
 		Update: resourceKongJWTCredentialUpdate,
 		Delete: resourceKongJWTCredentialDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"id": &schema.Schema{
 				Type:     schema.TypeString,

--- a/kong/resource_kong_consumer_credential_key_auth.go
+++ b/kong/resource_kong_consumer_credential_key_auth.go
@@ -22,7 +22,7 @@ func resourceKongKeyAuthCredential() *schema.Resource {
 		Delete: resourceKongKeyAuthCredentialDelete,
 
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: ImportConsumerCredential,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/kong/resource_kong_consumer_credential_key_auth.go
+++ b/kong/resource_kong_consumer_credential_key_auth.go
@@ -21,6 +21,10 @@ func resourceKongKeyAuthCredential() *schema.Resource {
 		Update: resourceKongKeyAuthCredentialUpdate,
 		Delete: resourceKongKeyAuthCredentialDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"id": &schema.Schema{
 				Type:     schema.TypeString,

--- a/kong/resource_kong_key_auth_plugin.go
+++ b/kong/resource_kong_key_auth_plugin.go
@@ -24,6 +24,10 @@ func resourceKongKeyAuthPlugin() *schema.Resource {
 		Update: resourceKeyAuthPluginUpdate,
 		Delete: resourceKeyAuthPluginDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"id": &schema.Schema{
 				Type:     schema.TypeString,

--- a/kong/resource_kong_key_auth_plugin.go
+++ b/kong/resource_kong_key_auth_plugin.go
@@ -14,7 +14,7 @@ type KeyAuthPlugin struct {
 	KeyNames      	 string                 `json:"config.key_names,omitempty"`
 	HideCredentials  bool                   `json:"config.hide_credentials,omitempty"`
 	Anonymous        string                  `json:"config.anonymous,omitempty"`
-	API              string                 `json:"-"`
+	API              string                 `json:"api_id,omitempty"`
 }
 
 func resourceKongKeyAuthPlugin() *schema.Resource {

--- a/kong/resource_kong_key_auth_plugin.go
+++ b/kong/resource_kong_key_auth_plugin.go
@@ -75,7 +75,9 @@ func resourceKeyAuthPluginCreate(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Error while creating plugin.")
 	}
 
-	if response.StatusCode != http.StatusCreated {
+	if response.StatusCode == http.StatusConflict {
+		return fmt.Errorf("409 Conflict - use terraform import to manage this plugin.")
+	} else if response.StatusCode != http.StatusCreated {
 		return fmt.Errorf(response.Status)
 	}
 


### PR DESCRIPTION
* Support import of all kong terraform resources.
* Return a more specific error for 409 Conflict
    * In the case that a user hits a conflict when creating a new resource they should use terraform import to start managing the resource through the terraform kong provider.

Known caveats:

1. `terraform import` of a `kong_api` resource will show a "change" in the `hosts`. 
<pre>
<b>$ terraform state rm kong_api.api</b>
<b>$ terraform import kong_api.api 8bb0de31-40ef-4894-8417-24a19dc78488</b>
kong_api.api: Importing from ID "8bb0de31-40ef-4894-8417-24a19dc78488"...
kong_api.api: Import complete!
  Imported kong_api (ID: 8bb0de31-40ef-4894-8417-24a19dc78488)
kong_api.api: Refreshing state... (ID: 8bb0de31-40ef-4894-8417-24a19dc78488)

<b>$ terraform plan -target kong_api.api</b>
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

kong_api.api: Refreshing state... (ID: 8bb0de31-40ef-4894-8417-24a19dc78488)

------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
<b>  ~ update in-place</b>

Terraform will perform the following actions:
<b>
  ~ kong_api.api
      hosts: "" => "api.domain.com"
</b>

Plan: 0 to add, 1 to change, 0 to destroy.
</pre>

2. `terraform import` of credentials must use the `<consumer id>/<credential id>` format:
<pre>
<b>$ CONSUMER=2e2e99fd-a70a-43f2-af24-d7562ef5a9ff
$ CREDENTIAL_ID=f822cb5a-d9bf-4707-a0a9-078ed4f4ff92
$ terraform import kong_consumer_key_auth_credential.test $CONSUMER/$CREDENTIAL_ID</b>
kong_consumer_key_auth_credential.test: Importing from ID "2e2e99fd-a70a-43f2-af24-d7562ef5a9ff/f822cb5a-d9bf-4707-a0a9-078ed4f4ff92"...
kong_consumer_key_auth_credential.test: Import complete!
  Imported kong_consumer_key_auth_credential (ID: f822cb5a-d9bf-4707-a0a9-078ed4f4ff92)
kong_consumer_key_auth_credential.test: Refreshing state... (ID: f822cb5a-d9bf-4707-a0a9-078ed4f4ff92)

Import successful!
</pre>