### PR TITLE
Support specifying consumer_id for plugin resources

### DIFF
--- a/kong/resource_kong_api_plugin.go
+++ b/kong/resource_kong_api_plugin.go
@@ -14,6 +14,7 @@ type Plugin struct {
 	Name          string                 `json:"name,omitempty"`
 	Configuration map[string]interface{} `json:"config,omitempty"`
 	API           string                 `json:"-"`
+	Consumer      string                 `json:"consumer_id,omitempty"`
 }
 
 func resourceKongPlugin() *schema.Resource {
@@ -27,6 +28,13 @@ func resourceKongPlugin() *schema.Resource {
 			"id": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+
+			"consumer": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     nil,
+				Description: "The id of the consumer to scope this plugin to.",
 			},
 
 			"name": &schema.Schema{
@@ -145,6 +153,7 @@ func getPluginFromResourceData(d *schema.ResourceData) *Plugin {
 		Name:          d.Get("name").(string),
 		Configuration: d.Get("config").(map[string]interface{}),
 		API:           d.Get("api").(string),
+		Consumer:      d.Get("consumer").(string),
 	}
 
 	if id, ok := d.GetOk("id"); ok {
@@ -159,4 +168,5 @@ func setPluginToResourceData(d *schema.ResourceData, plugin *Plugin) {
 	d.Set("name", plugin.Name)
 	d.Set("config", plugin.Configuration)
 	d.Set("api", plugin.API)
+	d.Set("consumer", plugin.Consumer)
 }


### PR DESCRIPTION
```hcl
resource "kong_consumer" "bad_consumer" {
  username  = "joe_evil"
}

resource "kong_api_plugin" "request_termination_bad_consumer" {
  api  = "${kong_api.api.id}"
  name = "request-termination"

  # Use the `consumer` key to specify the consumer id:
  consumer = "${kong_consumer.bad_consumer.id}"

  config {
    status_code = 418
  }
}
```