### PR TITLE
Make api_id optional for kong plugin resources

### DIFF
--- a/kong/resource_kong_api_plugin.go
+++ b/kong/resource_kong_api_plugin.go
@@ -60,7 +60,7 @@ func resourceKongPluginCreate(d *schema.ResourceData, meta interface{}) error {
 	createdPlugin := getPluginFromResourceData(d)
 
 	request := sling.New().BodyJSON(plugin)
-	if plugin.API != nil {
+	if plugin.API != "" {
 		request = request.Path("apis/").Path(plugin.API + "/")
 	}
 	response, error := request.Post("plugins/").ReceiveSuccess(createdPlugin)

--- a/kong/resource_kong_api_plugin.go
+++ b/kong/resource_kong_api_plugin.go
@@ -45,7 +45,8 @@ func resourceKongPlugin() *schema.Resource {
 
 			"api": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Default:  nil,
 			},
 		},
 	}
@@ -58,7 +59,11 @@ func resourceKongPluginCreate(d *schema.ResourceData, meta interface{}) error {
 
 	createdPlugin := getPluginFromResourceData(d)
 
-	response, error := sling.New().BodyJSON(plugin).Path("apis/").Path(plugin.API + "/").Post("plugins/").ReceiveSuccess(createdPlugin)
+	request := sling.New().BodyJSON(plugin)
+	if plugin.API != nil {
+		request = request.Path("apis/").Path(plugin.API + "/")
+	}
+	response, error := request.Post("plugins/").ReceiveSuccess(createdPlugin)
 	if error != nil {
 		return fmt.Errorf("error while creating plugin: " + error.Error())
 	}
@@ -84,7 +89,7 @@ func resourceKongPluginRead(d *schema.ResourceData, meta interface{}) error {
         configuration[key] = value
     }
 
-	response, error := sling.New().Path("apis/").Path(plugin.API + "/").Path("plugins/").Get(plugin.ID).ReceiveSuccess(plugin)
+	response, error := sling.New().Path("plugins/").Get(plugin.ID).ReceiveSuccess(plugin)
 	if error != nil {
 		return fmt.Errorf("error while updating plugin: " + error.Error())
 	}
@@ -107,7 +112,7 @@ func resourceKongPluginUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	updatedPlugin := getPluginFromResourceData(d)
 
-	response, error := sling.New().BodyJSON(plugin).Path("apis/").Path(plugin.API + "/").Path("plugins/").Patch(plugin.ID).ReceiveSuccess(updatedPlugin)
+	response, error := sling.New().BodyJSON(plugin).Path("plugins/").Patch(plugin.ID).ReceiveSuccess(updatedPlugin)
 	if error != nil {
 		return fmt.Errorf("error while updating plugin: " + error.Error())
 	}
@@ -128,7 +133,7 @@ func resourceKongPluginDelete(d *schema.ResourceData, meta interface{}) error {
 
 	plugin := getPluginFromResourceData(d)
 
-	response, error := sling.New().Path("apis/").Path(plugin.API + "/").Path("plugins/").Delete(plugin.ID).ReceiveSuccess(nil)
+	response, error := sling.New().Path("plugins/").Delete(plugin.ID).ReceiveSuccess(nil)
 	if error != nil {
 		return fmt.Errorf("error while deleting plugin: " + error.Error())
 	}

--- a/kong/resource_kong_key_auth_plugin.go
+++ b/kong/resource_kong_key_auth_plugin.go
@@ -68,7 +68,7 @@ func resourceKeyAuthPluginCreate(d *schema.ResourceData, meta interface{}) error
 	createdPlugin := getKeyAuthPluginFromResourceData(d)
 
 	request := sling.New().BodyJSON(plugin)
-	if plugin.API != nil {
+	if plugin.API != "" {
 		request = request.Path("apis/").Path(plugin.API + "/")
 	}
 	response, error := request.Post("plugins/").ReceiveSuccess(createdPlugin)

--- a/kong/resource_kong_key_auth_plugin.go
+++ b/kong/resource_kong_key_auth_plugin.go
@@ -53,7 +53,8 @@ func resourceKongKeyAuthPlugin() *schema.Resource {
 
 			"api": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Default:  nil,
 			},
 		},
 	}
@@ -66,7 +67,11 @@ func resourceKeyAuthPluginCreate(d *schema.ResourceData, meta interface{}) error
 
 	createdPlugin := getKeyAuthPluginFromResourceData(d)
 
-	response, error := sling.New().BodyJSON(plugin).Path("apis/").Path(plugin.API + "/").Post("plugins/").ReceiveSuccess(createdPlugin)
+	request := sling.New().BodyJSON(plugin)
+	if plugin.API != nil {
+		request = request.Path("apis/").Path(plugin.API + "/")
+	}
+	response, error := request.Post("plugins/").ReceiveSuccess(createdPlugin)
 	if error != nil {
 		return fmt.Errorf("Error while creating plugin.")
 	}
@@ -85,7 +90,7 @@ func resourceKeyAuthPluginRead(d *schema.ResourceData, meta interface{}) error {
 
 	plugin := getKeyAuthPluginFromResourceData(d)
 
-	response, error := sling.New().Path("apis/").Path(plugin.API + "/").Path("plugins/").Get(plugin.ID).ReceiveSuccess(plugin)
+	response, error := sling.New().Path("plugins/").Get(plugin.ID).ReceiveSuccess(plugin)
 	if error != nil {
 		return fmt.Errorf("Error while updating plugin.")
 	}
@@ -106,7 +111,7 @@ func resourceKeyAuthPluginUpdate(d *schema.ResourceData, meta interface{}) error
 
 	updatedPlugin := getKeyAuthPluginFromResourceData(d)
 
-	response, error := sling.New().BodyJSON(plugin).Path("apis/").Path(plugin.API + "/").Path("plugins/").Patch(plugin.ID).ReceiveSuccess(updatedPlugin)
+	response, error := sling.New().BodyJSON(plugin).Path("plugins/").Patch(plugin.ID).ReceiveSuccess(updatedPlugin)
 	if error != nil {
 		return fmt.Errorf("Error while updating plugin.")
 	}
@@ -125,7 +130,7 @@ func resourceKeyAuthPluginDelete(d *schema.ResourceData, meta interface{}) error
 
 	plugin := getKeyAuthPluginFromResourceData(d)
 
-	response, error := sling.New().Path("apis/").Path(plugin.API + "/").Path("plugins/").Delete(plugin.ID).ReceiveSuccess(nil)
+	response, error := sling.New().Path("plugins/").Delete(plugin.ID).ReceiveSuccess(nil)
 	if error != nil {
 		return fmt.Errorf("Error while deleting plugin.")
 	}

--- a/kong/resource_provider.go
+++ b/kong/resource_provider.go
@@ -29,6 +29,7 @@ func Provider() terraform.ResourceProvider {
 			"kong_api":                            resourceKongAPI(),
 			"kong_consumer":                       resourceKongConsumer(),
 			"kong_api_plugin":                     resourceKongPlugin(),
+			"kong_plugin":                         resourceKongPlugin(),
 			"kong_consumer_basic_auth_credential": resourceKongBasicAuthCredential(),
 			"kong_consumer_key_auth_credential":   resourceKongKeyAuthCredential(),
 			"kong_consumer_jwt_credential":        resourceKongJWTCredential(),


### PR DESCRIPTION
Only use api_id in path on POST (not required for updates).

**NOTE**: This does not add support for changing the `api_id` (which was still not possible before). Attempting to do so will cause kong to throw an http error.

This conflicts with #14 once either is merged the other should be rebased.